### PR TITLE
Add verification code screen for password recovery

### DIFF
--- a/lib/features/auth/presentation/new_password_page.dart
+++ b/lib/features/auth/presentation/new_password_page.dart
@@ -150,7 +150,20 @@ class _NewPasswordPageState extends State<NewPasswordPage> {
                                   surfaceTintColor: Colors.transparent,
                                 ),
                                 onPressed: () {
-                                  // TODO: enviar código de verificación
+                                  final trimmedEmail = email.text.trim();
+                                  if (trimmedEmail.isEmpty) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Por favor ingresa el correo registrado.',
+                                        ),
+                                      ),
+                                    );
+                                    return;
+                                  }
+
+                                  FocusScope.of(context).unfocus();
+                                  context.push('/verification');
                                 },
                                 child: const Text('Enviar código de verificación'),
                               ),

--- a/lib/features/auth/presentation/verification_page.dart
+++ b/lib/features/auth/presentation/verification_page.dart
@@ -1,52 +1,234 @@
-// TODO Implement this library.
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
-
 
 class VerificationPage extends StatefulWidget {
   const VerificationPage({super.key});
+
   @override
   State<VerificationPage> createState() => _VerificationPageState();
 }
 
-
 class _VerificationPageState extends State<VerificationPage> {
-  final controllers = List.generate(4, (_) => TextEditingController());
+  static const _codeLength = 4;
+
+  final List<TextEditingController> controllers =
+      List.generate(_codeLength, (_) => TextEditingController());
+  final List<FocusNode> focusNodes =
+      List.generate(_codeLength, (_) => FocusNode());
+
+  @override
+  void dispose() {
+    for (final controller in controllers) {
+      controller.dispose();
+    }
+    for (final node in focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onCodeChanged(int index, String value) {
+    if (value.length == 1 && index < focusNodes.length - 1) {
+      focusNodes[index + 1].requestFocus();
+    } else if (value.isEmpty && index > 0) {
+      focusNodes[index - 1].requestFocus();
+    }
+  }
+
+  void _onVerifyPressed() {
+    final code = controllers.map((controller) => controller.text.trim()).join();
+
+    if (code.length < _codeLength) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Por favor ingresa el código completo.'),
+        ),
+      );
+      return;
+    }
+
+    FocusScope.of(context).unfocus();
+    context.go('/success');
+  }
+
+  Widget _buildDigitField(int index) {
+    return SizedBox(
+      width: 60,
+      child: TextField(
+        controller: controllers[index],
+        focusNode: focusNodes[index],
+        keyboardType: TextInputType.number,
+        textAlign: TextAlign.center,
+        style: const TextStyle(
+          fontSize: 24,
+          fontWeight: FontWeight.w600,
+        ),
+        inputFormatters: const [
+          FilteringTextInputFormatter.digitsOnly,
+          LengthLimitingTextInputFormatter(1),
+        ],
+        textInputAction:
+            index == _codeLength - 1 ? TextInputAction.done : TextInputAction.next,
+        decoration: InputDecoration(
+          isDense: true,
+          counterText: '',
+          filled: true,
+          fillColor: Colors.white,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: const BorderSide(color: Color(0xFFD28AD9), width: 2),
+          ),
+        ),
+        onChanged: (value) => _onCodeChanged(index, value),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final viewInsets = MediaQuery.of(context).viewInsets.bottom;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Código de verificación')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
+      backgroundColor: Colors.black,
+      body: Stack(
+        fit: StackFit.expand,
         children: [
-          Image.asset('assets/ui/verify_bg.jpg', height: 160, fit: BoxFit.cover),
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: controllers
-                .map((c) => SizedBox(
-              width: 56,
-              child: TextField(
-                controller: c,
-                textAlign: TextAlign.center,
-                maxLength: 1,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(counterText: ''),
-              ),
-            ))
-                .toList(),
+          Image.asset(
+            'assets/ui/verify_bg.jpg',
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) => Container(color: Colors.black),
           ),
-          const SizedBox(height: 16),
-          SizedBox(
-            width: double.infinity,
-            height: 48,
-            child: ElevatedButton(
-              onPressed: () => context.go('/success'),
-              child: const Text('Verificar'),
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.black.withOpacity(0.05),
+                  Colors.black.withOpacity(0.6),
+                ],
+              ),
             ),
-          )
+          ),
+          SafeArea(
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: IconButton.filled(
+                  style: IconButton.styleFrom(
+                    backgroundColor: Colors.black.withOpacity(0.35),
+                  ),
+                  icon: const Icon(Icons.arrow_back, color: Colors.white),
+                  onPressed: () {
+                    if (context.canPop()) {
+                      context.pop();
+                    } else {
+                      context.go('/');
+                    }
+                  },
+                ),
+              ),
+            ),
+          ),
+          SafeArea(
+            bottom: true,
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: AnimatedPadding(
+                duration: const Duration(milliseconds: 150),
+                padding: EdgeInsets.fromLTRB(16, 8, 16, 16 + viewInsets),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 420),
+                  child: Container(
+                    width: double.infinity,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFD9D9D9),
+                      borderRadius: const BorderRadius.only(
+                        topLeft: Radius.circular(24),
+                        topRight: Radius.circular(24),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.45),
+                          blurRadius: 18,
+                          offset: const Offset(0, -4),
+                        ),
+                      ],
+                    ),
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(20, 28, 20, 24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const Center(
+                            child: Text(
+                              'Código de verificación',
+                              style: TextStyle(
+                                fontSize: 22,
+                                fontWeight: FontWeight.w700,
+                                color: Color(0xFFD28AD9),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          const Text(
+                            'Ingresa el código que llegó a tu correo',
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 24),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                            children: List.generate(
+                              _codeLength,
+                              (index) => _buildDigitField(index),
+                            ),
+                          ),
+                          const SizedBox(height: 28),
+                          DecoratedBox(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(12),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(0.25),
+                                  blurRadius: 14,
+                                  offset: const Offset(0, 6),
+                                ),
+                              ],
+                            ),
+                            child: SizedBox(
+                              height: 48,
+                              child: ElevatedButton(
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: Colors.black,
+                                  foregroundColor: Colors.white,
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  elevation: 0,
+                                  surfaceTintColor: Colors.transparent,
+                                ),
+                                onPressed: _onVerifyPressed,
+                                child: const Text('Verificar'),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
     );
   }
 }
+


### PR DESCRIPTION
## Summary
- add validation for the recovery email submission and route to the verification step
- redesign the verification page to match the provided mock, including digit inputs and navigation to success

## Testing
- flutter analyze *(fails: Flutter SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c94fe18d4c8321b92c043c0bbcb5fe