### PR TITLE
Add login validation using AuthValidators

### DIFF
--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'validators.dart';
+
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
   @override
@@ -144,6 +146,45 @@ class _LoginPageState extends State<LoginPage> {
                                   surfaceTintColor: Colors.transparent, // M3: evita tinte que aclare el botón
                                 ),
                                 onPressed: () {
+                                  final messenger =
+                                      ScaffoldMessenger.of(context);
+                                  final trimmedEmail = email.text.trim();
+                                  final trimmedPassword =
+                                      password.text.trim();
+
+                                  if (trimmedEmail.isEmpty) {
+                                    messenger.showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Por favor ingresa tu correo electrónico',
+                                        ),
+                                      ),
+                                    );
+                                    return;
+                                  }
+
+                                  if (!AuthValidators.isValidEmail(trimmedEmail)) {
+                                    messenger.showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'El correo electrónico no es válido',
+                                        ),
+                                      ),
+                                    );
+                                    return;
+                                  }
+
+                                  if (trimmedPassword.isEmpty) {
+                                    messenger.showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Por favor ingresa tu contraseña',
+                                        ),
+                                      ),
+                                    );
+                                    return;
+                                  }
+
                                   // TODO: login
                                 },
                                 child: const Text('Iniciar sesión'),

--- a/lib/features/auth/presentation/validators.dart
+++ b/lib/features/auth/presentation/validators.dart
@@ -1,0 +1,12 @@
+class AuthValidators {
+  AuthValidators._();
+
+  static final RegExp _emailRegExp = RegExp(
+    r'^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$',
+    caseSensitive: false,
+  );
+
+  static bool isValidEmail(String value) {
+    return _emailRegExp.hasMatch(value.trim());
+  }
+}


### PR DESCRIPTION
## Summary
- add an `AuthValidators` helper to centralize email validation logic
- use the shared validator on the login button, trimming inputs and showing SnackBar errors for empty or invalid fields

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb1dd694508321bcfd694ff23cb811