### PR TITLE
Validate email before navigating from new password page

### DIFF
--- a/lib/features/auth/presentation/auth_validators.dart
+++ b/lib/features/auth/presentation/auth_validators.dart
@@ -1,0 +1,10 @@
+class AuthValidators {
+  const AuthValidators._();
+
+  static bool isValidEmail(String email) {
+    final emailRegex = RegExp(
+      r'^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)+)([A-Za-z]{2,})$',
+    );
+    return emailRegex.hasMatch(email);
+  }
+}

--- a/lib/features/auth/presentation/new_password_page.dart
+++ b/lib/features/auth/presentation/new_password_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:nailfinderstore/features/auth/presentation/auth_validators.dart';
+
 class NewPasswordPage extends StatefulWidget {
   const NewPasswordPage({super.key});
   @override
@@ -156,6 +158,19 @@ class _NewPasswordPageState extends State<NewPasswordPage> {
                                       const SnackBar(
                                         content: Text(
                                           'Por favor ingresa el correo registrado.',
+                                        ),
+                                      ),
+                                    );
+                                    return;
+                                  }
+
+                                  final isEmailValid =
+                                      AuthValidators.isValidEmail(trimmedEmail);
+                                  if (!isEmailValid) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Por favor ingresa un correo electrónico válido.',
                                         ),
                                       ),
                                     );


### PR DESCRIPTION
## Summary
- add reusable AuthValidators helper with email validation logic
- import and use AuthValidators in the new password page to validate trimmed email input
- show a snackbar when the email is empty or invalid and only unfocus and navigate after validation passes

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cb1de59f188321a320b9cba5cf6823