### PR TITLE
Refine dashboard empty catalog experience

### DIFF
--- a/lib/features/auth/presentation/login_page.dart
+++ b/lib/features/auth/presentation/login_page.dart
@@ -24,7 +24,7 @@ class _LoginPageState extends State<LoginPage> {
         children: [
           // Fondo
           Image.asset(
-            'assets/ui/main_bg.jpg', // cámbialo a .png si corresponde
+            'assets/ui/main_bg.png',
             fit: BoxFit.cover,
             errorBuilder: (_, __, ___) => Container(color: Colors.black),
           ),

--- a/lib/features/auth/presentation/main_page.dart
+++ b/lib/features/auth/presentation/main_page.dart
@@ -11,11 +11,11 @@ class MainPage extends StatelessWidget {
         fit: StackFit.expand,
         children: [
           // Fondo
-          //Image.asset(
-            //'assets/ui/main_bg.jpg', // cambia a .png si corresponde
-            //fit: BoxFit.cover,
-            //errorBuilder: (_, __, ___) => Container(color: Colors.white),
-          //),
+          Image.asset(
+            'assets/ui/main_bg.png',
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) => Container(color: Colors.white),
+          ),
 
           // Gradiente para contraste
           Container(

--- a/lib/features/auth/presentation/register_page.dart
+++ b/lib/features/auth/presentation/register_page.dart
@@ -27,7 +27,7 @@ class _RegisterPageState extends State<RegisterPage> {
         children: [
           // HERO superior
           Image.asset(
-            'assets/ui/main_bg.jpg', // cambia a .png si corresponde
+            'assets/ui/main_bg.png',
             fit: BoxFit.cover,
             errorBuilder: (_, __, ___) => Container(color: Colors.black),
           ),

--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../application/catalog_providers.dart';
-import '../../data/models/service_category.dart';
-import '../../data/models/service.dart';
-import '../../data/models/technician.dart';
+import '../application/catalog_providers.dart';
+import '../data/models/service_category.dart';
+import '../data/models/service.dart';
+import '../data/models/technician.dart';
 
 class DashboardPage extends ConsumerStatefulWidget {
   const DashboardPage({super.key});
@@ -85,21 +85,30 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
               techniciansAsync: techniciansAsync,
             ),
             const SizedBox(height: 24),
-            OutlinedButton(
+            ElevatedButton(
               onPressed: () {},
-              style: OutlinedButton.styleFrom(
-                side: const BorderSide(color: Colors.black, width: 1.5),
-                foregroundColor: Colors.black,
-                padding: const EdgeInsets.symmetric(vertical: 14),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF7F3DFF),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 16),
                 shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
+                  borderRadius: BorderRadius.circular(32),
                 ),
+                elevation: 2,
               ),
-              child: Text(
-                isServicesSelected
-                    ? 'Ver más servicios...'
-                    : 'Ver más técnicos...',
-                style: const TextStyle(fontWeight: FontWeight.w600),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    isServicesSelected
+                        ? 'Ver más servicios...'
+                        : 'Ver más técnicos...',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 16,
+                    ),
+                  ),
+                ],
               ),
             ),
           ],
@@ -118,9 +127,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
         data: (services) {
           if (services.isEmpty) {
             return const [
-              _EmptyState(
-                message: 'No encontramos datos para mostrar por el momento.',
-              ),
+              _EmptyCatalogSection.services(),
             ];
           }
 
@@ -147,9 +154,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
       data: (technicians) {
         if (technicians.isEmpty) {
           return const [
-            _EmptyState(
-              message: 'No encontramos datos para mostrar por el momento.',
-            ),
+            _EmptyCatalogSection.technicians(),
           ];
         }
 
@@ -382,11 +387,28 @@ class _CoursesBanner extends StatelessWidget {
         children: [
           ClipRRect(
             borderRadius: BorderRadius.circular(16),
-            child: Image.network(
-              'https://images.unsplash.com/photo-1580983561920-5730476cef05?auto=format&fit=crop&w=240&q=80',
+            child: Container(
               width: 96,
               height: 96,
-              fit: BoxFit.cover,
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [Color(0xFF7F3DFF), Color(0xFFB892FF)],
+                ),
+              ),
+              alignment: Alignment.center,
+              child: Image.asset(
+                'assets/ui/logo_ui.png',
+                width: 56,
+                height: 56,
+                fit: BoxFit.contain,
+                errorBuilder: (_, __, ___) => const Icon(
+                  Icons.school,
+                  color: Colors.white,
+                  size: 40,
+                ),
+              ),
             ),
           ),
           const SizedBox(width: 16),
@@ -544,6 +566,318 @@ class _CategoriesChips extends StatelessWidget {
     );
   }
 }
+
+
+class _EmptyCatalogSection extends StatelessWidget {
+  const _EmptyCatalogSection.services()
+      : type = _CatalogEmptyType.services;
+  const _EmptyCatalogSection.technicians()
+      : type = _CatalogEmptyType.technicians;
+
+  final _CatalogEmptyType type;
+
+  Color get _accentColor => const Color(0xFF7F3DFF);
+
+  @override
+  Widget build(BuildContext context) {
+    final isServices = type == _CatalogEmptyType.services;
+    final theme = Theme.of(context);
+
+    final primaryActionLabel =
+        isServices ? 'Agregar servicio' : 'Invitar técnico';
+    final primaryActionIcon =
+        isServices ? Icons.add_circle_outline : Icons.person_add_alt_1_outlined;
+
+    final secondaryActionLabel =
+        isServices ? 'Importar catálogo' : 'Asignar servicios';
+    final secondaryActionIcon =
+        isServices ? Icons.cloud_upload_outlined : Icons.manage_accounts_outlined;
+
+    final title = isServices
+        ? 'Aún no hay servicios disponibles'
+        : 'Todavía no hay técnicos visibles';
+    final description = isServices
+        ? 'Publica tus servicios o sincroniza tu catálogo para mostrarlos aquí.'
+        : 'Añade a tu equipo o invita colaboradores para que aparezcan en este listado.';
+
+    final footer = Text(
+      isServices
+          ? 'Gestiona tu catálogo desde el panel de administración.'
+          : 'Administra los perfiles desde el panel de administración.',
+      style: const TextStyle(
+        color: Color(0xFF7F3DFF),
+        fontWeight: FontWeight.w600,
+        fontSize: 12,
+      ),
+    );
+
+    final highlights = isServices
+        ? const [
+            _EmptyHighlight(
+              icon: Icons.brush_outlined,
+              title: 'Destaca tus especialidades',
+              description:
+                  'Organiza tus servicios por categoría y duración para facilitar las reservas.',
+            ),
+            _EmptyHighlight(
+              icon: Icons.timer_outlined,
+              title: 'Define duraciones reales',
+              description:
+                  'Ajusta el tiempo estimado para que la agenda sugiera horarios disponibles.',
+            ),
+          ]
+        : const [
+            _EmptyHighlight(
+              icon: Icons.school_outlined,
+              title: 'Completa los perfiles',
+              description:
+                  'Incluye certificaciones y biografías para que los clientes confíen en tu equipo.',
+            ),
+            _EmptyHighlight(
+              icon: Icons.groups_outlined,
+              title: 'Asigna servicios compatibles',
+              description:
+                  'Relaciona a cada técnico con los servicios que puede atender antes de recibir reservas.',
+            ),
+          ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton.icon(
+              onPressed: () {},
+              style: ElevatedButton.styleFrom(
+                backgroundColor: _accentColor,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ),
+              icon: Icon(primaryActionIcon),
+              label: Text(
+                primaryActionLabel,
+                style: const TextStyle(fontWeight: FontWeight.w700),
+              ),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: () {},
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Colors.black,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                side: const BorderSide(color: Colors.black87, width: 1.1),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ),
+              icon: Icon(secondaryActionIcon, color: Colors.black87),
+              label: Text(
+                secondaryActionLabel,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: Colors.black,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 18),
+        _EmptyCollectionCard(
+          icon: isServices ? Icons.spa_outlined : Icons.people_alt_outlined,
+          title: title,
+          description: description,
+          footer: footer,
+        ),
+        const SizedBox(height: 18),
+        _EmptyHighlightsList(highlights: highlights),
+      ],
+    );
+  }
+}
+
+enum _CatalogEmptyType { services, technicians }
+
+class _EmptyHighlight {
+  const _EmptyHighlight({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+
+class _EmptyHighlightsList extends StatelessWidget {
+  const _EmptyHighlightsList({required this.highlights});
+
+  final List<_EmptyHighlight> highlights;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (var i = 0; i < highlights.length; i++) ...[
+          if (i > 0) const SizedBox(height: 12),
+          _EmptyHighlightTile(highlight: highlights[i]),
+        ],
+      ],
+    );
+  }
+}
+
+class _EmptyHighlightTile extends StatelessWidget {
+  const _EmptyHighlightTile({required this.highlight});
+
+  final _EmptyHighlight highlight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: const Color(0xFFE5DBFF)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.03),
+            blurRadius: 10,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            decoration: const BoxDecoration(
+              color: Color(0xFFF1ECFF),
+              shape: BoxShape.circle,
+            ),
+            padding: const EdgeInsets.all(10),
+            child: Icon(
+              highlight.icon,
+              color: const Color(0xFF7F3DFF),
+              size: 22,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  highlight.title,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: Colors.black,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  highlight.description,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: Colors.black87,
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+
+class _EmptyCollectionCard extends StatelessWidget {
+  const _EmptyCollectionCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    this.footer,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Widget? footer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 52,
+            height: 52,
+            decoration: BoxDecoration(
+              color: const Color(0xFFF1ECFF),
+              borderRadius: BorderRadius.circular(18),
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              icon,
+              color: const Color(0xFF7F3DFF),
+              size: 28,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  description,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    color: Colors.black87,
+                    height: 1.4,
+                  ),
+                ),
+                if (footer != null) ...[
+                  const SizedBox(height: 12),
+                  footer!,
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 
 class _ServiceTile extends StatelessWidget {
   const _ServiceTile({required this.service});


### PR DESCRIPTION
## Summary
- point login, register, and landing backgrounds to the existing PNG asset so the screens render without asset errors
- replace the dashboard courses banner network image with a bundled asset and gradient panel
- swap the dashboard empty-state placeholders for descriptive cards with guided actions so the catalog column keeps its structure even without data

## Testing
- not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc2d3c01948321a494a255e5b33086