### PR TITLE
Use canonical dashboard models

### DIFF
--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -3,9 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../application/catalog_providers.dart';
-import '../data/models/service.dart';
-import '../data/models/service_category.dart';
-import '../data/models/technician.dart';
+import 'package:nailfinderstore/features/dashboard/data/models/service.dart';
+import 'package:nailfinderstore/features/dashboard/data/models/service_category.dart';
+import 'package:nailfinderstore/features/dashboard/data/models/technician.dart';
 
 class DashboardPage extends ConsumerStatefulWidget {
   const DashboardPage({super.key});


### PR DESCRIPTION
## Summary
- update the dashboard page to import the shared Service, ServiceCategory, and Technician models via their canonical paths

## Testing
- `flutter analyze` *(fails: flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc46c6c2088321872a6b083c1b0645