### PR TITLE
Restore profile navigation on dashboard header

### DIFF
--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -1,25 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../application/catalog_providers.dart';
+import '../data/models/service.dart';
+import '../data/models/service_category.dart';
+import '../data/models/technician.dart';
 
+class DashboardPage extends ConsumerStatefulWidget {
   const DashboardPage({super.key});
 
   @override
-  State<DashboardPage> createState() => _DashboardPageState();
+  ConsumerState<DashboardPage> createState() => _DashboardPageState();
 }
 
-class _DashboardPageState extends State<DashboardPage> {
+class _DashboardPageState extends ConsumerState<DashboardPage> {
   String _segment = 'services';
-
-  final List<ServiceCategory> _categories = const [
-    ServiceCategory('Manicure'),
-    ServiceCategory('Spa'),
-    ServiceCategory('Diseños 3D'),
-  ];
-
-  final List<Service> _services = const [];
-
-  final List<Technician> _technicians = const [];
 
   void _onSegmentChanged(String segment) {
     setState(() {
@@ -31,6 +27,9 @@ class _DashboardPageState extends State<DashboardPage> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isServicesSelected = _segment == 'services';
+    final categoriesAsync = ref.watch(serviceCategoriesProvider);
+    final servicesAsync = ref.watch(servicesProvider);
+    final techniciansAsync = ref.watch(techniciansProvider);
 
     return Scaffold(
       backgroundColor: const Color(0xFFF7F3FF),
@@ -38,7 +37,10 @@ class _DashboardPageState extends State<DashboardPage> {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
           children: [
-            _HeaderBar(onNotificationsPressed: () {}),
+            _HeaderBar(
+              onNotificationsPressed: () {},
+              onProfilePressed: () => context.push('/profile'),
+            ),
             const SizedBox(height: 16),
             _NextReservationCard(),
             const SizedBox(height: 24),
@@ -77,12 +79,11 @@ class _DashboardPageState extends State<DashboardPage> {
               onChanged: _onSegmentChanged,
             ),
             const SizedBox(height: 20),
-            if (isServicesSelected && _categories.isNotEmpty) ...[
-              _CategoriesChips(categories: _categories),
-              const SizedBox(height: 20),
-            ],
             ..._buildSegmentContent(
               isServicesSelected: isServicesSelected,
+              categoriesAsync: categoriesAsync,
+              servicesAsync: servicesAsync,
+              techniciansAsync: techniciansAsync,
             ),
             const SizedBox(height: 24),
             ElevatedButton(
@@ -117,23 +118,80 @@ class _DashboardPageState extends State<DashboardPage> {
     );
   }
 
-  List<Widget> _buildSegmentContent({required bool isServicesSelected}) {
+  List<Widget> _buildSegmentContent({
+    required bool isServicesSelected,
+    required AsyncValue<List<ServiceCategory>> categoriesAsync,
+    required AsyncValue<List<Service>> servicesAsync,
+    required AsyncValue<List<Technician>> techniciansAsync,
+  }) {
     if (isServicesSelected) {
-
-          ),
+      return [
+        categoriesAsync.when(
+          data: (categories) {
+            if (categories.isEmpty) {
+              return const SizedBox.shrink();
+            }
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _CategoriesChips(categories: categories),
+                const SizedBox(height: 20),
+              ],
+            );
+          },
+          loading: () => const SizedBox.shrink(),
+          error: (_, __) => const SizedBox.shrink(),
+        ),
+        servicesAsync.when(
+          data: (services) {
+            if (services.isEmpty) {
+              return const _EmptyCatalogSection.services();
+            }
+            return Column(
+              children: [
+                for (var i = 0; i < services.length; i++) ...[
+                  if (i > 0) const SizedBox(height: 12),
+                  _ServiceTile(service: services[i]),
+                ],
+              ],
+            );
+          },
+          loading: () => const _CatalogLoadingIndicator(),
+          error: (error, _) => _CatalogErrorMessage(error: error),
+        ),
       ];
     }
 
-
-        ),
+    return [
+      techniciansAsync.when(
+        data: (technicians) {
+          if (technicians.isEmpty) {
+            return const _EmptyCatalogSection.technicians();
+          }
+          return Column(
+            children: [
+              for (var i = 0; i < technicians.length; i++) ...[
+                if (i > 0) const SizedBox(height: 12),
+                _TechnicianTile(technician: technicians[i]),
+              ],
+            ],
+          );
+        },
+        loading: () => const _CatalogLoadingIndicator(),
+        error: (error, _) => _CatalogErrorMessage(error: error),
+      ),
     ];
   }
 }
 
 class _HeaderBar extends StatelessWidget {
-  const _HeaderBar({required this.onNotificationsPressed});
+  const _HeaderBar({
+    required this.onNotificationsPressed,
+    required this.onProfilePressed,
+  });
 
   final VoidCallback onNotificationsPressed;
+  final VoidCallback onProfilePressed;
 
   @override
   Widget build(BuildContext context) {
@@ -161,8 +219,8 @@ class _HeaderBar extends StatelessWidget {
             ),
             const SizedBox(width: 12),
             _CircleIconButton(
-              icon: Icons.favorite_border,
-              onPressed: () {},
+              icon: Icons.person_outline,
+              onPressed: onProfilePressed,
             ),
             const SizedBox(width: 12),
             _CircleIconButton(
@@ -812,6 +870,74 @@ class _EmptyCollectionCard extends StatelessWidget {
   }
 }
 
+class _CatalogLoadingIndicator extends StatelessWidget {
+  const _CatalogLoadingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}
+
+class _CatalogErrorMessage extends StatelessWidget {
+  const _CatalogErrorMessage({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: const Color(0xFFE5DBFF)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.error_outline, color: Color(0xFF7F3DFF), size: 24),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Ocurrió un error al cargar la información.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: Colors.black,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '$error',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: Colors.black54,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 
 class _ServiceTile extends StatelessWidget {
@@ -1009,42 +1135,6 @@ class _TechnicianTile extends StatelessWidget {
       ),
     );
   }
-}
-
-class ServiceCategory {
-  const ServiceCategory(this.name);
-
-  final String name;
-}
-
-class Service {
-  const Service({
-    required this.name,
-    this.description,
-    this.durationMinutes,
-    this.price,
-  });
-
-  final String name;
-  final String? description;
-  final int? durationMinutes;
-  final double? price;
-}
-
-class Technician {
-  const Technician({
-    required this.displayName,
-    this.rating,
-    this.reviewsCount,
-    this.bio,
-    this.services = const <Service>[],
-  });
-
-  final String displayName;
-  final double? rating;
-  final int? reviewsCount;
-  final String? bio;
-  final List<Service> services;
 }
 
 String _formatCurrency(double value) {


### PR DESCRIPTION
## Summary
- restore the dashboard header profile action by wiring the button callback again
- pass the GoRouter profile navigation from the page state into the header widget

## Testing
- not run (Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc440978188321ab9db7c66ec6c876