### PR TITLE
Fix DashboardPage class declaration and restore catalog imports

### DIFF
--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -2,7 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-const DashboardPage({super.key});
+import '../application/catalog_providers.dart';
+import '../data/models/service.dart';
+import '../data/models/service_category.dart';
+import '../data/models/technician.dart';
+
+class DashboardPage extends ConsumerStatefulWidget {
+  const DashboardPage({super.key});
 
   @override
   ConsumerState<DashboardPage> createState() => _DashboardPageState();


### PR DESCRIPTION
## Summary
- restore the DashboardPage class declaration as a ConsumerStatefulWidget
- reintroduce the catalog provider and model imports used by the dashboard segment builders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc565148708321b993d17e24836019