### PR TITLE
Add sales and stores dashboards

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -10,6 +10,8 @@ import 'features/auth/presentation/success_page.dart';
 import 'features/dashboard/presentation/dashboard_page.dart';
 import 'features/dashboard/presentation/model_preview_page.dart';
 import 'features/dashboard/presentation/courses_page.dart';
+import 'features/dashboard/presentation/sales_page.dart';
+import 'features/dashboard/presentation/stores_page.dart';
 import 'features/profile/presentation/profile_page.dart';
 
 
@@ -19,6 +21,8 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(path: '/', builder: (_, __) => const DashboardPage()),
       GoRoute(path: '/model-preview', builder: (_, __) => const ModelPreviewPage()),
       GoRoute(path: '/courses', builder: (_, __) => const CoursesPage()),
+      GoRoute(path: '/sales', builder: (_, __) => const SalesPage()),
+      GoRoute(path: '/stores', builder: (_, __) => const StoresPage()),
       GoRoute(path: '/profile', builder: (_, __) => const ProfilePage()),
       GoRoute(path: '/welcome', builder: (_, __) => const MainPage()),
       GoRoute(path: '/login', builder: (_, __) => const LoginPage()),

--- a/lib/features/dashboard/presentation/courses_page.dart
+++ b/lib/features/dashboard/presentation/courses_page.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import 'dashboard_palette.dart';
+import 'widgets/dashboard_common_widgets.dart';
+
 class CoursesPage extends StatelessWidget {
   const CoursesPage({super.key});
 
@@ -29,23 +32,84 @@ class CoursesPage extends StatelessWidget {
       ),
     ];
 
+    final previewImages = const [
+      'https://images.pexels.com/photos/4543110/pexels-photo-4543110.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+      'https://images.pexels.com/photos/5240653/pexels-photo-5240653.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+      'https://images.pexels.com/photos/8101187/pexels-photo-8101187.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+      'https://images.pexels.com/photos/7567944/pexels-photo-7567944.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+    ];
+
+    final theme = Theme.of(context);
+    final coursesChildCount = courses.isEmpty ? 0 : courses.length * 2 - 1;
+
     return Scaffold(
-      backgroundColor: const Color(0xFFF7F3FF),
-      appBar: AppBar(
-        backgroundColor: const Color(0xFFF7F3FF),
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
-        centerTitle: true,
-        title: const Text(
-          'Cursos',
-          style: TextStyle(color: Colors.black, fontWeight: FontWeight.w700),
+      backgroundColor: kDashboardBackgroundColor,
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _CoursesHeaderBar(
+                      onBackPressed: () => Navigator.of(context).maybePop(),
+                    ),
+                    const SizedBox(height: 20),
+                    const DashboardReservationCard(),
+                    const SizedBox(height: 28),
+                    Text(
+                      'Prueba tu modelo',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: kDashboardDarkColor,
+                      ),
+                    ),
+                    const SizedBox(height: 14),
+                    SizedBox(
+                      height: 102,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: previewImages.length,
+                        separatorBuilder: (_, __) => const SizedBox(width: 12),
+                        itemBuilder: (_, index) => _ModelPreviewThumbnail(
+                          imageUrl: previewImages[index],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 28),
+                    Text(
+                      'Mejor valorados',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: kDashboardDarkColor,
+                      ),
+                    ),
+                    const SizedBox(height: 18),
+                    const _CoursesSegmentedControl(),
+                    const SizedBox(height: 20),
+                  ],
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
+              sliver: SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) {
+                    if (index.isOdd) {
+                      return const SizedBox(height: 16);
+                    }
+                    final courseIndex = index ~/ 2;
+                    return _CourseTile(item: courses[courseIndex]);
+                  },
+                  childCount: coursesChildCount,
+                ),
+              ),
+            ),
+          ],
         ),
-      ),
-      body: ListView.separated(
-        padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
-        itemCount: courses.length,
-        separatorBuilder: (_, __) => const SizedBox(height: 16),
-        itemBuilder: (_, index) => _CourseTile(item: courses[index]),
       ),
     );
   }
@@ -81,11 +145,15 @@ class _CourseTile extends StatelessWidget {
               width: 80,
               height: 80,
               fit: BoxFit.cover,
-              errorBuilder: (_, __, ___) => Image.asset(
-                'assets/ui/course_placeholder.png',
+              errorBuilder: (_, __, ___) => Container(
                 width: 80,
                 height: 80,
-                fit: BoxFit.cover,
+                color: kDashboardCardTintColor,
+                alignment: Alignment.center,
+                child: const Icon(
+                  Icons.image_not_supported_outlined,
+                  color: kDashboardDarkColor,
+                ),
               ),
             ),
           ),
@@ -148,4 +216,129 @@ class _CourseItem {
   final String price;
   final String description;
   final String imageUrl;
+}
+
+class _ModelPreviewThumbnail extends StatelessWidget {
+  const _ModelPreviewThumbnail({required this.imageUrl});
+
+  final String imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(18),
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: Image.network(
+          imageUrl,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => Container(
+            color: kDashboardCardTintColor,
+            alignment: Alignment.center,
+            child: const Icon(
+              Icons.image_outlined,
+              color: kDashboardDarkColor,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CoursesHeaderBar extends StatelessWidget {
+  const _CoursesHeaderBar({required this.onBackPressed});
+
+  final VoidCallback onBackPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            DashboardCircleIconButton(
+              icon: Icons.arrow_back_ios_new_rounded,
+              onPressed: onBackPressed,
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.qr_code_2_rounded,
+              onPressed: () {},
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.share_outlined,
+              onPressed: () {},
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            DashboardCircleIconButton(
+              icon: Icons.notifications_none_rounded,
+              onPressed: () {},
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.person_outline,
+              onPressed: () {},
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.shopping_bag_outlined,
+              onPressed: () {},
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _CoursesSegmentedControl extends StatelessWidget {
+  const _CoursesSegmentedControl();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: kDashboardCardTintColor.withOpacity(0.65),
+        borderRadius: BorderRadius.circular(32),
+        border: Border.all(color: kDashboardDarkColor, width: 1.2),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 8),
+            decoration: BoxDecoration(
+              color: kDashboardDarkColor,
+              borderRadius: BorderRadius.circular(26),
+            ),
+            child: const Text(
+              'Cursos',
+              style: TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            child: Text(
+              'Talleres',
+              style: TextStyle(
+                color: kDashboardDarkColor.withOpacity(0.6),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/features/dashboard/presentation/courses_page.dart
+++ b/lib/features/dashboard/presentation/courses_page.dart
@@ -145,6 +145,20 @@ class _CourseTile extends StatelessWidget {
               width: 80,
               height: 80,
               fit: BoxFit.cover,
+              loadingBuilder: (context, child, loadingProgress) {
+                if (loadingProgress == null) {
+                  return child;
+                }
+                final expectedBytes = loadingProgress.expectedTotalBytes;
+                final progress = expectedBytes == null
+                    ? null
+                    : loadingProgress.cumulativeBytesLoaded / expectedBytes;
+                return _ImageLoadingPlaceholder(
+                  width: 80,
+                  height: 80,
+                  progress: progress,
+                );
+              },
               errorBuilder: (_, __, ___) => Container(
                 width: 80,
                 height: 80,
@@ -232,6 +246,16 @@ class _ModelPreviewThumbnail extends StatelessWidget {
         child: Image.network(
           imageUrl,
           fit: BoxFit.cover,
+          loadingBuilder: (context, child, loadingProgress) {
+            if (loadingProgress == null) {
+              return child;
+            }
+            final expectedBytes = loadingProgress.expectedTotalBytes;
+            final progress = expectedBytes == null
+                ? null
+                : loadingProgress.cumulativeBytesLoaded / expectedBytes;
+            return _ImageLoadingPlaceholder(progress: progress);
+          },
           errorBuilder: (_, __, ___) => Container(
             color: kDashboardCardTintColor,
             alignment: Alignment.center,
@@ -338,6 +362,33 @@ class _CoursesSegmentedControl extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _ImageLoadingPlaceholder extends StatelessWidget {
+  const _ImageLoadingPlaceholder({this.width, this.height, this.progress});
+
+  final double? width;
+  final double? height;
+  final double? progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      color: kDashboardCardTintColor.withOpacity(0.6),
+      alignment: Alignment.center,
+      child: SizedBox(
+        width: 22,
+        height: 22,
+        child: CircularProgressIndicator(
+          strokeWidth: 2.2,
+          value: progress,
+          valueColor: const AlwaysStoppedAnimation<Color>(kDashboardDarkColor),
+        ),
       ),
     );
   }

--- a/lib/features/dashboard/presentation/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/dashboard_page.dart
@@ -6,6 +6,9 @@ import '../application/catalog_providers.dart';
 import '../data/models/service.dart';
 import '../data/models/service_category.dart';
 import '../data/models/technician.dart';
+import 'dashboard_palette.dart';
+import 'widgets/dashboard_common_widgets.dart';
+import 'widgets/dashboard_courses_banner.dart';
 
 class DashboardPage extends ConsumerStatefulWidget {
   const DashboardPage({super.key});
@@ -33,7 +36,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
 
 
     return Scaffold(
-      backgroundColor: const Color(0xFFF7F3FF),
+      backgroundColor: kDashboardBackgroundColor,
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
@@ -43,13 +46,13 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
               onProfilePressed: () => context.push('/profile'),
             ),
             const SizedBox(height: 16),
-            _NextReservationCard(),
+            const DashboardReservationCard(),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () => context.push('/model-preview'),
               style: ElevatedButton.styleFrom(
                 padding: const EdgeInsets.symmetric(vertical: 16),
-                backgroundColor: Colors.black,
+                backgroundColor: kDashboardDarkColor,
                 foregroundColor: Colors.white,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
@@ -64,14 +67,14 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
             const SizedBox(height: 20),
             GestureDetector(
               onTap: () => context.push('/courses'),
-              child: const _CoursesBanner(),
+              child: const DashboardCoursesBanner(),
             ),
             const SizedBox(height: 28),
             Text(
               'Mejor valorados',
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.w700,
-                color: Colors.black,
+                color: kDashboardDarkColor,
               ),
             ),
             const SizedBox(height: 16),
@@ -92,8 +95,8 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
             ElevatedButton(
               onPressed: () {},
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF7F3DFF),
-                foregroundColor: Colors.white,
+                backgroundColor: kDashboardAccentColor,
+                foregroundColor: kDashboardDarkColor,
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(32),
@@ -188,6 +191,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
   }
 }
 
+
 class _HeaderBar extends StatelessWidget {
   const _HeaderBar({
     required this.onNotificationsPressed,
@@ -204,12 +208,12 @@ class _HeaderBar extends StatelessWidget {
       children: [
         Row(
           children: [
-            _CircleIconButton(
+            DashboardCircleIconButton(
               icon: Icons.qr_code_2_rounded,
               onPressed: () {},
             ),
             const SizedBox(width: 12),
-            _CircleIconButton(
+            DashboardCircleIconButton(
               icon: Icons.share_outlined,
               onPressed: () {},
             ),
@@ -217,247 +221,23 @@ class _HeaderBar extends StatelessWidget {
         ),
         Row(
           children: [
-            _CircleIconButton(
+            DashboardCircleIconButton(
               icon: Icons.notifications_none_rounded,
               onPressed: onNotificationsPressed,
             ),
             const SizedBox(width: 12),
-            _CircleIconButton(
+            DashboardCircleIconButton(
               icon: Icons.person_outline,
               onPressed: onProfilePressed,
             ),
             const SizedBox(width: 12),
-            _CircleIconButton(
+            DashboardCircleIconButton(
               icon: Icons.shopping_bag_outlined,
               onPressed: () {},
             ),
           ],
         ),
       ],
-    );
-  }
-}
-
-class _CircleIconButton extends StatelessWidget {
-  const _CircleIconButton({required this.icon, required this.onPressed});
-
-  final IconData icon;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: Colors.white,
-      shape: const CircleBorder(),
-      elevation: 2,
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onPressed,
-        child: SizedBox(
-          width: 42,
-          height: 42,
-          child: Icon(icon, color: Colors.black87, size: 22),
-        ),
-      ),
-    );
-  }
-}
-
-class _NextReservationCard extends StatelessWidget {
-  const _NextReservationCard();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(24),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 12,
-            offset: const Offset(0, 6),
-          ),
-        ],
-      ),
-      padding: const EdgeInsets.all(20),
-      child: Row(
-        children: [
-          Container(
-            width: 66,
-            height: 92,
-            decoration: BoxDecoration(
-              color: const Color(0xFF5B1CFB),
-              borderRadius: BorderRadius.circular(18),
-            ),
-            padding: const EdgeInsets.symmetric(vertical: 12),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: const [
-                Text(
-                  '15',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                SizedBox(height: 4),
-                Text(
-                  'DIC',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: 18),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  'Próxima reserva',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w700,
-                    fontSize: 16,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  'Nail Finder Store',
-                  style: TextStyle(
-                    color: Colors.grey.shade900,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 16,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  'Avenida Yucatán 69, Ciudad de México',
-                  style: TextStyle(
-                    color: Colors.grey.shade600,
-                    fontSize: 13,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    const Icon(Icons.access_time, size: 18, color: Colors.black87),
-                    const SizedBox(width: 6),
-                    Text(
-                      '05:30 PM',
-                      style: TextStyle(
-                        color: Colors.grey.shade900,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    const Spacer(),
-                    TextButton(
-                      onPressed: () {},
-                      style: TextButton.styleFrom(
-                        foregroundColor: const Color(0xFF5B1CFB),
-                      ),
-                      child: const Text('Cómo llegar'),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _CoursesBanner extends StatelessWidget {
-  const _CoursesBanner();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
-          colors: [Color(0xFFFAE5D2), Color(0xFFE8D0F7)],
-        ),
-        borderRadius: BorderRadius.circular(24),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.08),
-            blurRadius: 10,
-            offset: const Offset(0, 6),
-          ),
-        ],
-      ),
-      padding: const EdgeInsets.all(18),
-      child: Row(
-        children: [
-          ClipRRect(
-            borderRadius: BorderRadius.circular(16),
-            child: Container(
-              width: 96,
-              height: 96,
-              decoration: const BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors: [Color(0xFF7F3DFF), Color(0xFFB892FF)],
-                ),
-              ),
-              alignment: Alignment.center,
-              child: Image.asset(
-                'assets/ui/logo_ui.png',
-                width: 56,
-                height: 56,
-                fit: BoxFit.contain,
-                errorBuilder: (_, __, ___) => const Icon(
-                  Icons.school,
-                  color: Colors.white,
-                  size: 40,
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: const [
-                Text(
-                  'Cursos',
-                  style: TextStyle(
-                    color: Colors.black54,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 14,
-                  ),
-                ),
-                SizedBox(height: 6),
-                Text(
-                  'Aprende o actualízate',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                SizedBox(height: 8),
-                Text(
-                  'Descubre talleres y cursos para mejorar tus técnicas profesionales.',
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: Colors.black87,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
     );
   }
 }
@@ -475,9 +255,9 @@ class _SegmentedSelector extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: kDashboardCardTintColor,
         borderRadius: BorderRadius.circular(30),
-        border: Border.all(color: Colors.black, width: 1.2),
+        border: Border.all(color: kDashboardDarkColor, width: 1.2),
       ),
       padding: const EdgeInsets.all(4),
       child: Row(
@@ -518,14 +298,14 @@ class _SegmentButton extends StatelessWidget {
           duration: const Duration(milliseconds: 200),
           padding: const EdgeInsets.symmetric(vertical: 12),
           decoration: BoxDecoration(
-            color: selected ? Colors.black : Colors.transparent,
+            color: selected ? kDashboardDarkColor : Colors.transparent,
             borderRadius: BorderRadius.circular(26),
           ),
           alignment: Alignment.center,
           child: Text(
             label,
             style: TextStyle(
-              color: selected ? Colors.white : Colors.black,
+              color: selected ? Colors.white : kDashboardDarkColor,
               fontWeight: FontWeight.w600,
               fontSize: 15,
             ),
@@ -555,7 +335,8 @@ class _CategoriesChips extends StatelessWidget {
           final category = categories[index];
           return Chip(
             label: Text(category.name),
-            backgroundColor: const Color(0xFFF1ECFF),
+            backgroundColor: kDashboardAccentColorLighter,
+            labelStyle: const TextStyle(color: kDashboardDarkColor, fontWeight: FontWeight.w500),
           );
         },
       ),
@@ -571,8 +352,6 @@ class _EmptyCatalogSection extends StatelessWidget {
       : type = _CatalogEmptyType.technicians;
 
   final _CatalogEmptyType type;
-
-  Color get _accentColor => const Color(0xFF7F3DFF);
 
   @override
   Widget build(BuildContext context) {
@@ -601,10 +380,9 @@ class _EmptyCatalogSection extends StatelessWidget {
           ? 'Gestiona tu catálogo desde el panel de administración.'
           : 'Administra los perfiles desde el panel de administración.',
       style: const TextStyle(
-        color: Color(0xFF7F3DFF),
         fontWeight: FontWeight.w600,
         fontSize: 12,
-      ),
+      ).copyWith(color: kDashboardAccentColor),
     );
 
     final highlights = isServices
@@ -646,7 +424,7 @@ class _EmptyCatalogSection extends StatelessWidget {
             ElevatedButton.icon(
               onPressed: () {},
               style: ElevatedButton.styleFrom(
-                backgroundColor: _accentColor,
+                backgroundColor: kDashboardAccentColor,
                 foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(vertical: 14),
                 shape: RoundedRectangleBorder(
@@ -663,19 +441,19 @@ class _EmptyCatalogSection extends StatelessWidget {
             OutlinedButton.icon(
               onPressed: () {},
               style: OutlinedButton.styleFrom(
-                foregroundColor: Colors.black,
+                foregroundColor: kDashboardDarkColor,
                 padding: const EdgeInsets.symmetric(vertical: 14),
-                side: const BorderSide(color: Colors.black87, width: 1.1),
+                side: const BorderSide(color: kDashboardDarkColor, width: 1.1),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(20),
                 ),
               ),
-              icon: Icon(secondaryActionIcon, color: Colors.black87),
+              icon: Icon(secondaryActionIcon, color: kDashboardDarkColor),
               label: Text(
                 secondaryActionLabel,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   fontWeight: FontWeight.w700,
-                  color: Colors.black,
+                  color: kDashboardDarkColor,
                 ),
               ),
             ),
@@ -730,13 +508,13 @@ class _EmptyHighlightTile extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: kDashboardBackgroundColor,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: const Color(0xFFE5DBFF)),
+        border: Border.all(color: kDashboardAccentColorLighter),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.03),
-            blurRadius: 10,
+            color: kDashboardAccentColorLight.withOpacity(0.15),
+            blurRadius: 12,
             offset: const Offset(0, 6),
           ),
         ],
@@ -747,13 +525,13 @@ class _EmptyHighlightTile extends StatelessWidget {
         children: [
           Container(
             decoration: const BoxDecoration(
-              color: Color(0xFFF1ECFF),
+              color: kDashboardAccentColorLighter,
               shape: BoxShape.circle,
             ),
             padding: const EdgeInsets.all(10),
             child: Icon(
               highlight.icon,
-              color: const Color(0xFF7F3DFF),
+              color: kDashboardAccentColor,
               size: 22,
             ),
           ),
@@ -766,14 +544,14 @@ class _EmptyHighlightTile extends StatelessWidget {
                   highlight.title,
                   style: theme.textTheme.titleSmall?.copyWith(
                     fontWeight: FontWeight.w700,
-                    color: Colors.black,
+                    color: kDashboardDarkColor,
                   ),
                 ),
                 const SizedBox(height: 6),
                 Text(
                   highlight.description,
                   style: theme.textTheme.bodySmall?.copyWith(
-                    color: Colors.black87,
+                    color: kDashboardDarkColor.withOpacity(0.8),
                     height: 1.35,
                   ),
                 ),
@@ -804,12 +582,12 @@ class _EmptyCollectionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: kDashboardBackgroundColor,
         borderRadius: BorderRadius.circular(24),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 8,
+            color: kDashboardAccentColorLight.withOpacity(0.2),
+            blurRadius: 12,
             offset: const Offset(0, 6),
           ),
         ],
@@ -822,13 +600,13 @@ class _EmptyCollectionCard extends StatelessWidget {
             width: 52,
             height: 52,
             decoration: BoxDecoration(
-              color: const Color(0xFFF1ECFF),
+              color: kDashboardAccentColorLighter,
               borderRadius: BorderRadius.circular(18),
             ),
             alignment: Alignment.center,
             child: Icon(
               icon,
-              color: const Color(0xFF7F3DFF),
+              color: kDashboardAccentColor,
               size: 28,
             ),
           ),
@@ -842,14 +620,14 @@ class _EmptyCollectionCard extends StatelessWidget {
                   style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w700,
-                  ),
+                  ).copyWith(color: kDashboardDarkColor),
                 ),
                 const SizedBox(height: 8),
                 Text(
                   description,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 13,
-                    color: Colors.black87,
+                    color: kDashboardDarkColor.withOpacity(0.8),
                     height: 1.4,
                   ),
                 ),
@@ -891,13 +669,13 @@ class _CatalogErrorMessage extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: kDashboardBackgroundColor,
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: const Color(0xFFE5DBFF)),
+        border: Border.all(color: kDashboardAccentColorLighter),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 8,
+            color: kDashboardAccentColorLight.withOpacity(0.2),
+            blurRadius: 12,
             offset: const Offset(0, 6),
           ),
         ],
@@ -906,7 +684,7 @@ class _CatalogErrorMessage extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Icon(Icons.error_outline, color: Color(0xFF7F3DFF), size: 24),
+          const Icon(Icons.error_outline, color: kDashboardAccentColor, size: 24),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -916,14 +694,14 @@ class _CatalogErrorMessage extends StatelessWidget {
                   'Ocurrió un error al cargar la información.',
                   style: theme.textTheme.bodyMedium?.copyWith(
                     fontWeight: FontWeight.w600,
-                    color: Colors.black,
+                    color: kDashboardDarkColor,
                   ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   '$error',
                   style: theme.textTheme.bodySmall?.copyWith(
-                    color: Colors.black54,
+                    color: kDashboardDarkColor.withOpacity(0.7),
                   ),
                 ),
               ],
@@ -949,12 +727,12 @@ class _ServiceTile extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: kDashboardBackgroundColor,
         borderRadius: BorderRadius.circular(24),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 8,
+            color: kDashboardAccentColorLight.withOpacity(0.2),
+            blurRadius: 12,
             offset: const Offset(0, 6),
           ),
         ],
@@ -971,17 +749,18 @@ class _ServiceTile extends StatelessWidget {
                   style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w700,
-                  ),
+                  ).copyWith(color: kDashboardDarkColor),
                 ),
               ),
               if (service.durationMinutes != null)
                 Row(
                   children: [
-                    const Icon(Icons.schedule, size: 18, color: Colors.black54),
+                    const Icon(Icons.schedule, size: 18, color: kDashboardDarkColor),
                     const SizedBox(width: 4),
                     Text(
                       '${service.durationMinutes} min',
-                      style: const TextStyle(fontWeight: FontWeight.w600),
+                      style: const TextStyle(fontWeight: FontWeight.w600)
+                          .copyWith(color: kDashboardDarkColor),
                     ),
                   ],
                 ),
@@ -991,21 +770,22 @@ class _ServiceTile extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               description!,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 13,
                 height: 1.4,
-                color: Colors.black87,
+                color: kDashboardDarkColor.withOpacity(0.8),
               ),
             ),
           ],
           const SizedBox(height: 12),
           Row(
             children: [
-              const Icon(Icons.shopping_bag_outlined, size: 20, color: Colors.black87),
+              const Icon(Icons.shopping_bag_outlined, size: 20, color: kDashboardDarkColor),
               const SizedBox(width: 6),
               Text(
                 price != null ? _formatCurrency(price) : 'Precio según consulta',
-                style: const TextStyle(fontWeight: FontWeight.w600),
+                style: const TextStyle(fontWeight: FontWeight.w600)
+                    .copyWith(color: kDashboardDarkColor),
               ),
             ],
           ),
@@ -1026,12 +806,12 @@ class _TechnicianTile extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: kDashboardBackgroundColor,
         borderRadius: BorderRadius.circular(24),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 8,
+            color: kDashboardAccentColorLight.withOpacity(0.2),
+            blurRadius: 12,
             offset: const Offset(0, 6),
           ),
         ],
@@ -1047,7 +827,7 @@ class _TechnicianTile extends StatelessWidget {
               gradient: const LinearGradient(
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
-                colors: [Color(0xFFF1ECFF), Color(0xFFE6D9FF)],
+                colors: [kDashboardAccentColorLighter, kDashboardAccentColorLight],
               ),
               borderRadius: BorderRadius.circular(24),
             ),
@@ -1055,7 +835,7 @@ class _TechnicianTile extends StatelessWidget {
             child: const Icon(
               Icons.person_outline,
               size: 30,
-              color: Color(0xFF7F3DFF),
+              color: kDashboardAccentColor,
             ),
           ),
           const SizedBox(width: 16),
@@ -1071,23 +851,26 @@ class _TechnicianTile extends StatelessWidget {
                         style: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w700,
-                        ),
+                        ).copyWith(color: kDashboardDarkColor),
                       ),
                     ),
                     if (technician.rating != null)
                       Row(
                         children: [
-                          const Icon(Icons.star, color: Color(0xFFFFC107), size: 20),
+                          const Icon(Icons.star, color: kDashboardHighlightYellow, size: 20),
                           const SizedBox(width: 4),
                           Text(
                             technician.rating!.toStringAsFixed(1),
-                            style: const TextStyle(fontWeight: FontWeight.w600),
+                            style: const TextStyle(fontWeight: FontWeight.w600)
+                                .copyWith(color: kDashboardDarkColor),
                           ),
                           if (technician.reviewsCount != null) ...[
                             const SizedBox(width: 6),
                             Text(
                               '(${technician.reviewsCount})',
-                              style: const TextStyle(color: Colors.black54),
+                              style: TextStyle(
+                                color: kDashboardDarkColor.withOpacity(0.7),
+                              ),
                             ),
                           ],
                         ],
@@ -1098,10 +881,10 @@ class _TechnicianTile extends StatelessWidget {
                   const SizedBox(height: 8),
                   Text(
                     technician.bio!,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 13,
                       height: 1.4,
-                      color: Colors.black87,
+                      color: kDashboardDarkColor.withOpacity(0.8),
                     ),
                   ),
                 ],
@@ -1114,12 +897,14 @@ class _TechnicianTile extends StatelessWidget {
                       for (final service in services.take(3))
                         Chip(
                           label: Text(service.name),
-                          backgroundColor: const Color(0xFFF1ECFF),
+                          backgroundColor: kDashboardAccentColorLighter,
+                          labelStyle: const TextStyle(color: kDashboardDarkColor),
                         ),
                       if (services.length > 3)
                         Chip(
                           label: Text('+${services.length - 3} más'),
-                          backgroundColor: const Color(0xFFE8D0F7),
+                          backgroundColor: kDashboardAccentColorLight,
+                          labelStyle: const TextStyle(color: kDashboardDarkColor),
                         ),
                     ],
                   ),

--- a/lib/features/dashboard/presentation/dashboard_palette.dart
+++ b/lib/features/dashboard/presentation/dashboard_palette.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+const kDashboardDarkColor = Color(0xFF070008);
+const kDashboardAccentColor = Color(0xFFFF47F0);
+const kDashboardAccentColorLight = Color(0xFFFF87F4);
+const kDashboardAccentColorLighter = Color(0xFFFDA0F7);
+const kDashboardBackgroundColor = Color(0xFFFCE9FD);
+const kDashboardCardTintColor = Color(0xFFFBC5FA);
+const kDashboardSecondaryAccent = Color(0xFFE4B082);
+const kDashboardHighlightYellow = Color(0xFFFFD700);

--- a/lib/features/dashboard/presentation/sales_page.dart
+++ b/lib/features/dashboard/presentation/sales_page.dart
@@ -1,0 +1,491 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'dashboard_palette.dart';
+import 'widgets/dashboard_common_widgets.dart';
+import 'widgets/dashboard_courses_banner.dart';
+
+class SalesPage extends StatelessWidget {
+  const SalesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final popularProducts = const [
+      _ProductItem(
+        name: 'OPI Nail Lacquer',
+        description: 'Esmalte de alto brillo con acabado profesional y secado rápido.',
+        rating: 4.9,
+        price: '189 MXN',
+        imageUrl:
+            'https://images.pexels.com/photos/3993445/pexels-photo-3993445.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=400',
+      ),
+      _ProductItem(
+        name: 'Kit acrílico premium',
+        description: 'Incluye polvos, monómero y pinceles para crear estructuras resistentes.',
+        rating: 4.8,
+        price: '420 MXN',
+        imageUrl:
+            'https://images.pexels.com/photos/3997381/pexels-photo-3997381.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=400',
+      ),
+      _ProductItem(
+        name: 'Set de nail art brillante',
+        description: 'Cristales, foil y stickers para diseños sofisticados en minutos.',
+        rating: 4.7,
+        price: '310 MXN',
+        imageUrl:
+            'https://images.pexels.com/photos/3993442/pexels-photo-3993442.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=400',
+      ),
+    ];
+
+    final bestSellers = const [
+      _BestSellerItem(
+        name: 'Bloque pulidor 4 pasos',
+        price: '79 MXN',
+        imageUrl:
+            'https://images.pexels.com/photos/3993446/pexels-photo-3993446.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+      ),
+      _BestSellerItem(
+        name: 'Set de cutículas spa',
+        price: '105 MXN',
+        imageUrl:
+            'https://images.pexels.com/photos/3738349/pexels-photo-3738349.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+      ),
+      _BestSellerItem(
+        name: 'Gel constructor rosado',
+        price: '210 MXN',
+        imageUrl:
+            'https://images.pexels.com/photos/5240653/pexels-photo-5240653.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+      ),
+      _BestSellerItem(
+        name: 'Set de manicura dorado',
+        price: '260 MXN',
+        imageUrl:
+            'https://images.pexels.com/photos/3997382/pexels-photo-3997382.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=320',
+      ),
+    ];
+
+    final listChildCount = popularProducts.isEmpty ? 0 : popularProducts.length * 2 - 1;
+
+    return Scaffold(
+      backgroundColor: kDashboardBackgroundColor,
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _SalesHeaderBar(
+                      onBackPressed: () => context.pop(),
+                      onCartPressed: () {},
+                    ),
+                    const SizedBox(height: 20),
+                    const DashboardReservationCard(
+                      day: '16',
+                      month: 'DIC',
+                      time: '06:30 PM',
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: () => context.push('/model-preview'),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        backgroundColor: kDashboardDarkColor,
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        elevation: 2,
+                      ),
+                      child: const Text(
+                        'Prueba tu diseño en tiempo real',
+                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    const DashboardCoursesBanner(),
+                    const SizedBox(height: 28),
+                    Text(
+                      'Mejor valorados',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: kDashboardDarkColor,
+                          ),
+                    ),
+                    const SizedBox(height: 18),
+                    const _SalesSegmentedControl(activeTab: _SalesTab.products),
+                    const SizedBox(height: 20),
+                  ],
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              sliver: SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) {
+                    if (index.isOdd) {
+                      return const SizedBox(height: 16);
+                    }
+                    final item = popularProducts[index ~/ 2];
+                    return _ProductListTile(item: item);
+                  },
+                  childCount: listChildCount,
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(20, 28, 20, 8),
+              sliver: SliverToBoxAdapter(
+                child: Text(
+                  'Más vendidos',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: kDashboardDarkColor,
+                      ),
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              sliver: SliverGrid(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) => _BestSellerCard(item: bestSellers[index]),
+                  childCount: bestSellers.length,
+                ),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  mainAxisSpacing: 14,
+                  crossAxisSpacing: 14,
+                  childAspectRatio: 0.82,
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(20, 32, 20, 24),
+              sliver: SliverToBoxAdapter(
+                child: ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: kDashboardAccentColor,
+                    foregroundColor: kDashboardDarkColor,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(32),
+                    ),
+                    elevation: 2,
+                  ),
+                  child: const Text(
+                    'Ver 468 productos más...',
+                    style: TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SalesHeaderBar extends StatelessWidget {
+  const _SalesHeaderBar({
+    required this.onBackPressed,
+    required this.onCartPressed,
+  });
+
+  final VoidCallback onBackPressed;
+  final VoidCallback onCartPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            DashboardCircleIconButton(
+              icon: Icons.arrow_back_ios_new_rounded,
+              onPressed: onBackPressed,
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.qr_code_2_rounded,
+              onPressed: () {},
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.share_outlined,
+              onPressed: () {},
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            DashboardCircleIconButton(
+              icon: Icons.notifications_none_rounded,
+              onPressed: () {},
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.favorite_border,
+              onPressed: () {},
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.shopping_bag_outlined,
+              onPressed: onCartPressed,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+enum _SalesTab { stores, products }
+
+class _SalesSegmentedControl extends StatelessWidget {
+  const _SalesSegmentedControl({required this.activeTab});
+
+  final _SalesTab activeTab;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: kDashboardCardTintColor.withOpacity(0.7),
+        borderRadius: BorderRadius.circular(32),
+        border: Border.all(color: kDashboardDarkColor, width: 1.2),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _SegmentPill(
+            label: 'Tiendas',
+            selected: activeTab == _SalesTab.stores,
+          ),
+          const SizedBox(width: 8),
+          _SegmentPill(
+            label: 'Productos',
+            selected: activeTab == _SalesTab.products,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SegmentPill extends StatelessWidget {
+  const _SegmentPill({required this.label, required this.selected});
+
+  final String label;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 8),
+      decoration: BoxDecoration(
+        color: selected ? kDashboardDarkColor : Colors.transparent,
+        borderRadius: BorderRadius.circular(26),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: selected ? Colors.white : kDashboardDarkColor.withOpacity(0.65),
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+class _ProductListTile extends StatelessWidget {
+  const _ProductListTile({required this.item});
+
+  final _ProductItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Image.network(
+              item.imageUrl,
+              width: 80,
+              height: 80,
+              fit: BoxFit.cover,
+              errorBuilder: (_, __, ___) => Container(
+                width: 80,
+                height: 80,
+                color: kDashboardCardTintColor,
+                alignment: Alignment.center,
+                child: const Icon(
+                  Icons.image_not_supported_outlined,
+                  color: kDashboardDarkColor,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.name,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  item.description,
+                  style: TextStyle(
+                    fontSize: 12.5,
+                    height: 1.4,
+                    color: Colors.black.withOpacity(0.75),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    const Icon(Icons.star, size: 18, color: Colors.amber),
+                    const SizedBox(width: 4),
+                    Text(
+                      item.rating.toStringAsFixed(1),
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    const Spacer(),
+                    const Icon(Icons.favorite_border, color: kDashboardDarkColor, size: 20),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  item.price,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BestSellerCard extends StatelessWidget {
+  const _BestSellerCard({required this.item});
+
+  final _BestSellerItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(18),
+            child: AspectRatio(
+              aspectRatio: 1,
+              child: Image.network(
+                item.imageUrl,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => Container(
+                  color: kDashboardCardTintColor,
+                  alignment: Alignment.center,
+                  child: const Icon(
+                    Icons.image_outlined,
+                    color: kDashboardDarkColor,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            item.name,
+            style: const TextStyle(
+              fontWeight: FontWeight.w700,
+              fontSize: 14,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            item.price,
+            style: TextStyle(
+              color: kDashboardDarkColor.withOpacity(0.7),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProductItem {
+  const _ProductItem({
+    required this.name,
+    required this.description,
+    required this.rating,
+    required this.price,
+    required this.imageUrl,
+  });
+
+  final String name;
+  final String description;
+  final double rating;
+  final String price;
+  final String imageUrl;
+}
+
+class _BestSellerItem {
+  const _BestSellerItem({
+    required this.name,
+    required this.price,
+    required this.imageUrl,
+  });
+
+  final String name;
+  final String price;
+  final String imageUrl;
+}

--- a/lib/features/dashboard/presentation/stores_page.dart
+++ b/lib/features/dashboard/presentation/stores_page.dart
@@ -1,0 +1,359 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'dashboard_palette.dart';
+import 'widgets/dashboard_common_widgets.dart';
+import 'widgets/dashboard_courses_banner.dart';
+
+class StoresPage extends StatelessWidget {
+  const StoresPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final stores = const [
+      _StoreItem(
+        name: 'Tienditas',
+        description: 'Manicura y pedicura profesional con productos de alta calidad.',
+        rating: 4.9,
+        address: 'Roma Norte, CDMX',
+        imageUrl:
+            'https://images.pexels.com/photos/3738346/pexels-photo-3738346.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=400',
+      ),
+      _StoreItem(
+        name: 'Uñas para ti',
+        description: 'Ambiente acogedor con especialistas en diseño personalizado.',
+        rating: 4.8,
+        address: 'Col. del Valle, CDMX',
+        imageUrl:
+            'https://images.pexels.com/photos/8534278/pexels-photo-8534278.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=400',
+      ),
+      _StoreItem(
+        name: 'Mano bella',
+        description: 'Tratamientos modernos con las últimas tendencias en manicura.',
+        rating: 4.7,
+        address: 'Polanco, CDMX',
+        imageUrl:
+            'https://images.pexels.com/photos/8534277/pexels-photo-8534277.jpeg?auto=compress&cs=tinysrgb&dpr=2&w=400',
+      ),
+    ];
+
+    final childCount = stores.isEmpty ? 0 : stores.length * 2 - 1;
+
+    return Scaffold(
+      backgroundColor: kDashboardBackgroundColor,
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _StoresHeaderBar(
+                      onBackPressed: () => context.pop(),
+                    ),
+                    const SizedBox(height: 20),
+                    const DashboardReservationCard(),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: () => context.push('/model-preview'),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        backgroundColor: kDashboardDarkColor,
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        elevation: 2,
+                      ),
+                      child: const Text(
+                        'Prueba tu diseño en tiempo real',
+                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    const DashboardCoursesBanner(),
+                    const SizedBox(height: 28),
+                    Text(
+                      'Mejor valorados',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: kDashboardDarkColor,
+                          ),
+                    ),
+                    const SizedBox(height: 18),
+                    const _StoresSegmentedControl(activeTab: _StoresTab.stores),
+                    const SizedBox(height: 20),
+                  ],
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              sliver: SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) {
+                    if (index.isOdd) {
+                      return const SizedBox(height: 16);
+                    }
+                    final store = stores[index ~/ 2];
+                    return _StoreListTile(item: store);
+                  },
+                  childCount: childCount,
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(20, 32, 20, 24),
+              sliver: SliverToBoxAdapter(
+                child: ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: kDashboardAccentColor,
+                    foregroundColor: kDashboardDarkColor,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(32),
+                    ),
+                    elevation: 2,
+                  ),
+                  child: const Text(
+                    'Ver 231 tiendas más...',
+                    style: TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StoresHeaderBar extends StatelessWidget {
+  const _StoresHeaderBar({required this.onBackPressed});
+
+  final VoidCallback onBackPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            DashboardCircleIconButton(
+              icon: Icons.arrow_back_ios_new_rounded,
+              onPressed: onBackPressed,
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.qr_code_2_rounded,
+              onPressed: () {},
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.share_outlined,
+              onPressed: () {},
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            DashboardCircleIconButton(
+              icon: Icons.notifications_none_rounded,
+              onPressed: _noop,
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.favorite_border,
+              onPressed: _noop,
+            ),
+            const SizedBox(width: 12),
+            DashboardCircleIconButton(
+              icon: Icons.store_outlined,
+              onPressed: _noop,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+void _noop() {}
+
+enum _StoresTab { stores, products }
+
+class _StoresSegmentedControl extends StatelessWidget {
+  const _StoresSegmentedControl({required this.activeTab});
+
+  final _StoresTab activeTab;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: kDashboardCardTintColor.withOpacity(0.7),
+        borderRadius: BorderRadius.circular(32),
+        border: Border.all(color: kDashboardDarkColor, width: 1.2),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _SegmentPill(
+            label: 'Tiendas',
+            selected: activeTab == _StoresTab.stores,
+          ),
+          const SizedBox(width: 8),
+          _SegmentPill(
+            label: 'Productos',
+            selected: activeTab == _StoresTab.products,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SegmentPill extends StatelessWidget {
+  const _SegmentPill({required this.label, required this.selected});
+
+  final String label;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 8),
+      decoration: BoxDecoration(
+        color: selected ? kDashboardDarkColor : Colors.transparent,
+        borderRadius: BorderRadius.circular(26),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: selected ? Colors.white : kDashboardDarkColor.withOpacity(0.65),
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+class _StoreListTile extends StatelessWidget {
+  const _StoreListTile({required this.item});
+
+  final _StoreItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Image.network(
+              item.imageUrl,
+              width: 80,
+              height: 80,
+              fit: BoxFit.cover,
+              errorBuilder: (_, __, ___) => Container(
+                width: 80,
+                height: 80,
+                color: kDashboardCardTintColor,
+                alignment: Alignment.center,
+                child: const Icon(
+                  Icons.store_mall_directory_outlined,
+                  color: kDashboardDarkColor,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.name,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  item.description,
+                  style: TextStyle(
+                    fontSize: 12.5,
+                    height: 1.4,
+                    color: Colors.black.withOpacity(0.75),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    const Icon(Icons.star, size: 18, color: Colors.amber),
+                    const SizedBox(width: 4),
+                    Text(
+                      item.rating.toStringAsFixed(1),
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    const SizedBox(width: 12),
+                    const Icon(Icons.location_on_outlined, size: 18, color: kDashboardDarkColor),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        item.address,
+                        style: TextStyle(
+                          color: kDashboardDarkColor.withOpacity(0.7),
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    const Icon(Icons.favorite_border, color: kDashboardDarkColor, size: 20),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StoreItem {
+  const _StoreItem({
+    required this.name,
+    required this.description,
+    required this.rating,
+    required this.address,
+    required this.imageUrl,
+  });
+
+  final String name;
+  final String description;
+  final double rating;
+  final String address;
+  final String imageUrl;
+}

--- a/lib/features/dashboard/presentation/widgets/dashboard_common_widgets.dart
+++ b/lib/features/dashboard/presentation/widgets/dashboard_common_widgets.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import '../dashboard_palette.dart';
+
+class DashboardCircleIconButton extends StatelessWidget {
+  const DashboardCircleIconButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: kDashboardCardTintColor,
+      shape: const CircleBorder(),
+      elevation: 2,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onPressed,
+        child: SizedBox(
+          width: 42,
+          height: 42,
+          child: Icon(icon, color: kDashboardDarkColor, size: 22),
+        ),
+      ),
+    );
+  }
+}
+
+class DashboardReservationCard extends StatelessWidget {
+  const DashboardReservationCard({
+    super.key,
+    this.day = '15',
+    this.month = 'DIC',
+    this.storeName = 'Nail Finder Store',
+    this.address = 'Avenida Yucatán 69, Ciudad de México',
+    this.time = '05:30 PM',
+    this.onDirectionsTap,
+  });
+
+  final String day;
+  final String month;
+  final String storeName;
+  final String address;
+  final String time;
+  final VoidCallback? onDirectionsTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: kDashboardCardTintColor,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: kDashboardAccentColorLight.withOpacity(0.25),
+            blurRadius: 16,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(20),
+      child: Row(
+        children: [
+          Container(
+            width: 66,
+            height: 92,
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [kDashboardAccentColor, kDashboardAccentColorLight],
+              ),
+              borderRadius: BorderRadius.circular(18),
+            ),
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  day,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  month,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 18),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Próxima reserva',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                  ).copyWith(color: kDashboardDarkColor),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  storeName,
+                  style: const TextStyle(
+                    color: kDashboardDarkColor,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  address,
+                  style: TextStyle(
+                    color: kDashboardDarkColor.withOpacity(0.6),
+                    fontSize: 13,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    const Icon(Icons.access_time, size: 18, color: kDashboardDarkColor),
+                    const SizedBox(width: 6),
+                    Text(
+                      time,
+                      style: const TextStyle(
+                        color: kDashboardDarkColor,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const Spacer(),
+                    TextButton(
+                      onPressed: onDirectionsTap,
+                      style: TextButton.styleFrom(
+                        foregroundColor: kDashboardAccentColor,
+                      ),
+                      child: const Text('Cómo llegar'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/presentation/widgets/dashboard_courses_banner.dart
+++ b/lib/features/dashboard/presentation/widgets/dashboard_courses_banner.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import '../dashboard_palette.dart';
+
+class DashboardCoursesBanner extends StatelessWidget {
+  const DashboardCoursesBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.centerLeft,
+          end: Alignment.centerRight,
+          colors: [kDashboardSecondaryAccent, kDashboardAccentColorLight],
+        ),
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: kDashboardAccentColor.withOpacity(0.2),
+            blurRadius: 14,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(18),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              width: 96,
+              height: 96,
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [kDashboardAccentColor, kDashboardAccentColorLight],
+                ),
+              ),
+              alignment: Alignment.center,
+              child: Image.asset(
+                'assets/ui/logo_ui.png',
+                width: 56,
+                height: 56,
+                fit: BoxFit.contain,
+                errorBuilder: (_, __, ___) => const Icon(
+                  Icons.school,
+                  color: Colors.white,
+                  size: 40,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Cursos',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                  ).copyWith(color: kDashboardAccentColor),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Aprende o actualízate',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                  ).copyWith(color: kDashboardDarkColor),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Descubre talleres y cursos para mejorar tus técnicas profesionales.',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: kDashboardDarkColor.withOpacity(0.75),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract the dashboard palette and shared header/reservation widgets for reuse across screens
- add the sales and stores pages with curated product and store data that match the dashboard styling
- register new routes so the sales and stores screens are available from the router

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc598b444c832183e152c62070921a